### PR TITLE
Rename everything in the repo to can-define-*

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-# Contributing to can-rest-model
+# Contributing to can-define-rest-model
 
 ## Developing Locally
 
-This section will walk you through setting up the [repository](https://github.com/canjs/can-rest-model) on your computer.
+This section will walk you through setting up the [repository](https://github.com/canjs/can-define-rest-model) on your computer.
 
 ### Signing up for GitHub
 
@@ -12,14 +12,14 @@ If you don’t already have a GitHub account, you’ll need to [create a new one
 
 A “fork” is a copy of a repository in your personal GitHub account. “Cloning” is the process of getting the repository’s source code on your computer.
 
-GitHub has a guide for [forking a repo](https://help.github.com/articles/fork-a-repo/). To fork can-rest-model, you can start by going to its [fork page](https://github.com/canjs/can-rest-model/fork).
+GitHub has a guide for [forking a repo](https://help.github.com/articles/fork-a-repo/). To fork can-define-rest-model, you can start by going to its [fork page](https://github.com/canjs/can-define-rest-model/fork).
 
 Next, you’ll want to clone the repo. [GitHub’s cloning guide](https://help.github.com/articles/cloning-a-repository/) explains how to do this on Linux, Mac, or Windows.
 
 GitHub’s guide will [instruct you](https://help.github.com/articles/fork-a-repo/#step-2-create-a-local-clone-of-your-fork) to clone it with a command like:
 
 ```shell
-git clone https://github.com/YOUR-USERNAME/can-rest-model
+git clone https://github.com/YOUR-USERNAME/can-define-rest-model
 ```
 
 Make sure you replace `YOUR-USERNAME` with your GitHub username.
@@ -33,7 +33,7 @@ First, make sure you’ve [installed Node.js and npm](https://docs.npmjs.com/get
 If you just cloned the repo from the command line, you’ll want to switch to the folder with your clone:
 
 ```shell
-cd can-rest-model
+cd can-define-rest-model
 ```
 
 Next, install the project’s dependencies with npm:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Join our Discourse](https://img.shields.io/discourse/https/forums.bitovi.com/posts.svg)](https://forums.bitovi.com/?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/canjs/can-define-rest-model/blob/master/LICENSE)
 [![npm version](https://badge.fury.io/js/can-define-rest-model.svg)](https://www.npmjs.com/package/can-define-rest-model)
-[![Travis build status](https://travis-ci.org/canjs/can-define-rest-model.svg?branch=master)](https://travis-ci.org/canjs/can-define-rest-model)
+[![Travis build status](https://travis-ci.com/canjs/can-define-rest-model.svg?branch=master)](https://travis-ci.com/canjs/can-define-rest-model)
 [![Greenkeeper badge](https://badges.greenkeeper.io/canjs/can-define-rest-model.svg)](https://greenkeeper.io/)
 
 Connect a map to a rest connection

--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
-# can-rest-model
+# can-define-rest-model
 
 [![Join our Slack](https://img.shields.io/badge/slack-join%20chat-611f69.svg)](https://www.bitovi.com/community/slack?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Join our Discourse](https://img.shields.io/discourse/https/forums.bitovi.com/posts.svg)](https://forums.bitovi.com/?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/canjs/can-rest-model/blob/master/LICENSE)
-[![npm version](https://badge.fury.io/js/can-rest-model.svg)](https://www.npmjs.com/package/can-rest-model)
-[![Travis build status](https://travis-ci.org/canjs/can-rest-model.svg?branch=master)](https://travis-ci.org/canjs/can-rest-model)
-[![Greenkeeper badge](https://badges.greenkeeper.io/canjs/can-rest-model.svg)](https://greenkeeper.io/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/canjs/can-define-rest-model/blob/master/LICENSE)
+[![npm version](https://badge.fury.io/js/can-define-rest-model.svg)](https://www.npmjs.com/package/can-define-rest-model)
+[![Travis build status](https://travis-ci.org/canjs/can-define-rest-model.svg?branch=master)](https://travis-ci.org/canjs/can-define-rest-model)
+[![Greenkeeper badge](https://badges.greenkeeper.io/canjs/can-define-rest-model.svg)](https://greenkeeper.io/)
 
 Connect a map to a rest connection
 
 ## Documentation
 
-Read the [can-rest-model API docs on CanJS.com](https://canjs.com/doc/can-rest-model.html).
+Read the [can-define-rest-model API docs on CanJS.com](https://canjs.com/doc/can-define-rest-model.html).
 
 ## Changelog
 
-See the [latest releases on GitHub](https://github.com/canjs/can-rest-model/releases).
+See the [latest releases on GitHub](https://github.com/canjs/can-define-rest-model/releases).
 
 ## Contributing
 
-The [contribution guide](https://github.com/canjs/can-rest-model/blob/master/CONTRIBUTING.md) has information on getting help, reporting bugs, developing locally, and more.
+The [contribution guide](https://github.com/canjs/can-define-rest-model/blob/master/CONTRIBUTING.md) has information on getting help, reporting bugs, developing locally, and more.
 
 ## License
 
-[MIT](https://github.com/canjs/can-rest-model/blob/master/LICENSE)
+[MIT](https://github.com/canjs/can-define-rest-model/blob/master/LICENSE)

--- a/can-define-rest-model-test.js
+++ b/can-define-rest-model-test.js
@@ -2,10 +2,10 @@ var QUnit = require("steal-qunit");
 var fixture = require("can-fixture");
 var DefineMap = require("can-define/map/map");
 var DefineList = require("can-define/list/list");
-var restModel = require("./can-rest-model");
+var defineRestModel = require("./can-define-rest-model");
 var canReflect = require("can-reflect");
 
-QUnit.module("can-realtime-rest-model");
+QUnit.module("can-define-realtime-rest-model");
 
 
 QUnit.test("CRUD basics", function(assert){
@@ -35,7 +35,7 @@ QUnit.test("CRUD basics", function(assert){
         "#": Todo
     });
 
-    restModel({
+    defineRestModel({
         Map: Todo,
         List: TodoList,
         url: "/api/todos/{_id}"
@@ -159,7 +159,7 @@ QUnit.test("CRUD basics", function(assert){
 });
 
 QUnit.test("string signature", function(assert) {
-    var connection = restModel("/api/todos/{_id}");
+    var connection = defineRestModel("/api/todos/{_id}");
 
     assert.ok(new connection.Map() instanceof DefineMap, "Map defined");
     assert.ok(new connection.List() instanceof DefineList, "List defined");

--- a/can-define-rest-model.js
+++ b/can-define-rest-model.js
@@ -7,7 +7,7 @@ var DefineMap = require("can-define/map/map");
 var namespace = require("can-namespace");
 var base = require("can-connect/base/base");
 
-function restModel(optionsOrUrl) {
+function defineRestModel(optionsOrUrl) {
 
 	// If optionsOrUrl is a string, make options = {url: optionsOrUrl}
 	var options = (typeof optionsOrUrl === "string") ? {url: optionsOrUrl} : optionsOrUrl;
@@ -27,4 +27,4 @@ function restModel(optionsOrUrl) {
 	return connection;
 }
 
-module.exports = namespace.restModel = restModel;
+module.exports = namespace.defineRestModel = defineRestModel;

--- a/can-define-rest-model.md
+++ b/can-define-rest-model.md
@@ -1,26 +1,26 @@
-@module {function} can-rest-model
+@module {function} can-define-rest-model
 @parent can-data-modeling
-@collection can-core
+@collection can-legacy
 @package ./package.json
 @outline 2
 
 Connect a type to a restful service layer.
 
-@signature `restModel(options)`
+@signature `defineRestModel(options)`
 
-`restModel` extends the provided `options.Map` type
+`defineRestModel` extends the provided `options.Map` type
 with the ability to connect to a restful service layer. For example,
 the following extends a `Todo` type
 with the ability to connect to a restful service layer:
 
 ```js
 import {Todo, todoFixture} from "//unpkg.com/can-demo-models@5";
-import {restModel} from "can";
+import {defineRestModel} from "can";
 
 // Creates a mock backend with 5 todos
 todoFixture(5);
 
-Todo.connection = restModel({
+Todo.connection = defineRestModel({
     Map: Todo,
     List: Todo.List,
     url: "/api/todos/{id}"
@@ -35,7 +35,7 @@ Todo.getList().then(todos => {
 ```
   @codepen
 
-`restModel` mixes in the following behaviors:
+`defineRestModel` mixes in the following behaviors:
 
 - [can-connect/constructor/constructor]
 - [can-connect/can/map/map]
@@ -91,7 +91,7 @@ Todo.getList().then(todos => {
 
 @return {connection} Returns a connection object.
 
-@signature `restModel(url)`
+@signature `defineRestModel(url)`
 
 Create a connection with just a url. Use this if you do not need to pass in any other `options` to configure the connection.
 
@@ -99,12 +99,12 @@ For example, the following creates a `Todo` type with the ability to connect to 
 
 ```js
 import {todoFixture} from "//unpkg.com/can-demo-models@5";
-import {restModel} from "can";
+import {defineRestModel} from "can";
 
 // Creates a mock backend with 5 todos
 todoFixture(5);
 
-const Todo = restModel("/api/todos/{id}").Map;
+const Todo = defineRestModel("/api/todos/{id}").Map;
 
 // Prints out all todo names
 Todo.getList().then(todos => {
@@ -119,22 +119,22 @@ Todo.getList().then(todos => {
   delete data.
 
 @return {connection} A connection that is the combination of the options and all the behaviors
-that `restModel` adds. The `connection` includes a `Map` property which is the type
+that `defineRestModel` adds. The `connection` includes a `Map` property which is the type
 constructor function used to create instances of the raw record data retrieved from the server.
 
 @body
 
 ## Use
 
-Use `restModel` to build a simple connection to a restful service
-layer. To use `restModel`, you:
+Use `defineRestModel` to build a simple connection to a restful service
+layer. To use `defineRestModel`, you:
 
 - Define data types to connect to the service layer
 - Configure the connection to the service layer
 - Use the types to manipulate service data
 
-`restModel` is the most
-basic built-in CanJS model layer. Check out [can-realtime-rest-model] for models that
+`defineRestModel` is the most
+basic built-in CanJS model layer. Check out [can-define-realtime-rest-model] for models that
 are able to:
 
 - Add and remove data from lists automatically
@@ -149,7 +149,7 @@ to hold and manipulate data on the server.  The following defines:
 - ` TodoList` type to represent a list of todos
 
 ```js
-import {DefineMap, DefineList, restModel} from "can";
+import {DefineMap, DefineList, defineRestModel} from "can";
 
 const Todo = DefineMap.extend("Todo",{
     id: {type: "number", identity: true},
@@ -251,7 +251,7 @@ makes updating the subtask easier.  The following makes it so calling a `subtask
 calls it's `todo`'s `.save()` method:
 
 ```js
-import {DefineMap, DefineList, restModel} from "//unpkg.com/can@5/core.mjs";
+import {DefineMap, DefineList, defineRestModel} from "//unpkg.com/can@5/core.mjs";
 import {todoFixture} from "//unpkg.com/can-demo-models@5";
 
 // Model subtask
@@ -324,8 +324,8 @@ Todo.List = DefineList.extend("TodoList",{
 // Sets up a can-fixture as the backend
 todoFixture(0);
 
-// Creates a restModel
-Todo.connection = restModel({
+// Creates a defineRestModel
+Todo.connection = defineRestModel({
     Map: Todo,
     List: Todo.List,
     url: "/api/todos/{id}"
@@ -350,7 +350,7 @@ Todo.getList().then(todos => console.log(todos[0].subtasks[0].completed));
 
 #### The identity property
 
-If you're specifying the identity property on nested data types, `restModel` will be able to
+If you're specifying the identity property on nested data types, `defineRestModel` will be able to
 intelligently merge data.  For example, say a `Todo` and its nested `User` type are defined as follows:
 
 ```js
@@ -429,7 +429,7 @@ If your service layer matches what CanJS expects, this configuration
 might be as simple as the following:
 
 ```js
-Todo.connection = restModel({
+Todo.connection = defineRestModel({
     Map: Todo,
     List: Todo.List,
     url: "/api/todos/{id}"
@@ -496,7 +496,7 @@ The `url` option can be configured with individual urls used to create, retrieve
 and delete data:
 
 ```js
-Todo.connection = restModel({
+Todo.connection = defineRestModel({
     Map: Todo,
     List: Todo.List,
     url: {
@@ -514,9 +514,9 @@ resolves to the expected data format.  The following makes `getListData` use
 `fetch` to request JSON data:
 
 ```js
-import { param, restModel } from "can";
+import { param, defineRestModel } from "can";
 
-Todo.connection = restModel({
+Todo.connection = defineRestModel({
     Map: Todo,
     List: Todo.List,
     url: {
@@ -552,7 +552,7 @@ to fix the formatting.  For example, if `GET /api/todos` returned data like:
 You could correct this with [can-connect/data/parse/parse.parseListProp] like:
 
 ```js
-Todo.connection = restModel({
+Todo.connection = defineRestModel({
     Map: Todo,
     List: Todo.List,
     url: "/api/todos/{id}",
@@ -569,12 +569,12 @@ methods on `Todo` and instances of `Todo`:
 
 ```js
 import {Todo, todoFixture} from "//unpkg.com/can-demo-models@5";
-import {restModel} from "can";
+import {defineRestModel} from "can";
 
 // Creates a mock backend with 5 todos
 todoFixture(5);
 
-Todo.connection = restModel({
+Todo.connection = defineRestModel({
     Map: Todo,
     List: Todo.List,
     url: "/api/todos/{id}"
@@ -603,7 +603,7 @@ todo.destroy() //-> Promise<Todo>
 ```
 @codepen
 
-`restModel` also mixes in methods that let you know if the
+`defineRestModel` also mixes in methods that let you know if the
 object is being saved, destroyed, or has already been created:
 
 - [can-connect/can/map/map.prototype.isSaving]
@@ -625,7 +625,7 @@ update:
 <button disabled:from="todo.isSaving()">Update</button>
 ```
 
-`restModel` also makes the type and instances of the type emit events when items
+`defineRestModel` also makes the type and instances of the type emit events when items
 are created, updated or destroyed:
 
 ```js

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "can-rest-model",
+  "name": "can-define-rest-model",
   "version": "1.1.1",
   "description": "Connect a map to a rest connection",
   "homepage": "http://canjs.com",
   "repository": {
     "type": "git",
-    "url": "git://github.com/canjs/can-rest-model.git"
+    "url": "git://github.com/canjs/can-define-rest-model.git"
   },
   "author": {
     "name": "DoneJS Core Team",
@@ -27,7 +27,7 @@
     "build": "node build.js",
     "develop": "done-serve --static --develop --port 8080"
   },
-  "main": "can-rest-model",
+  "main": "can-define-rest-model",
   "keywords": [
     "canjs",
     "donejs",

--- a/test-ie.html
+++ b/test-ie.html
@@ -1,4 +1,4 @@
 <!doctype html>
-<title>can-rest-model</title>
-<script src="node_modules/steal/steal-with-promises.js" main="can-rest-model/test"></script>
+<title>can-define-rest-model</title>
+<script src="node_modules/steal/steal-with-promises.js" main="can-define-rest-model/test"></script>
 <div id="qunit-fixture"></div>

--- a/test.html
+++ b/test.html
@@ -1,4 +1,4 @@
 <!doctype html>
-<title>can-rest-model</title>
-<script src="node_modules/steal/steal.js" main="can-rest-model/test"></script>
+<title>can-define-rest-model</title>
+<script src="node_modules/steal/steal.js" main="can-define-rest-model/test"></script>
 <div id="qunit-fixture"></div>

--- a/test.js
+++ b/test.js
@@ -1,1 +1,1 @@
-import './can-rest-model-test';
+import './can-define-rest-model-test';


### PR DESCRIPTION
Also categorize this as part of the legacy collection.

Part of https://github.com/canjs/canjs/issues/5207